### PR TITLE
Problem: no way to run submission checks automatically 

### DIFF
--- a/lib/zhr_devs/application.ex
+++ b/lib/zhr_devs/application.ex
@@ -4,15 +4,17 @@ defmodule ZhrDevs.Application do
 
   alias ZhrDevs.{IdentityManagement, Submissions}
 
+  alias ZhrDevs.Otp.ProcessManagersSupervisor
   alias ZhrDevs.Otp.ProjectionsSupervisor
 
   @impl true
   def start(_type, _args) do
     children = [
       ZhrDevs.App,
+      ProjectionsSupervisor,
+      ProcessManagersSupervisor,
       IdentityManagement.EventHandler,
       Submissions.EventHandler,
-      ProjectionsSupervisor,
       {Plug.Cowboy,
        scheme: :http,
        plug: ZhrDevs.Web.PublicRouter,

--- a/lib/zhr_devs/otp/process_managers_supervisor.ex
+++ b/lib/zhr_devs/otp/process_managers_supervisor.ex
@@ -1,0 +1,22 @@
+defmodule ZhrDevs.Otp.ProcessManagersSupervisor do
+  @moduledoc """
+  This is a high-level supervisor that will supervise all the process managers
+  """
+
+  @dialyzer {:no_return, {:init, 1}}
+
+  use Supervisor
+
+  def start_link([]) do
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @impl Supervisor
+  def init([]) do
+    children = [
+      ZhrDevs.Submissions.ProcessManagers.CheckSolution
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one, name: __MODULE__)
+  end
+end

--- a/lib/zhr_devs/submissions/aggregates/check.ex
+++ b/lib/zhr_devs/submissions/aggregates/check.ex
@@ -1,0 +1,75 @@
+defmodule ZhrDevs.Submissions.Aggregates.Check do
+  @moduledoc """
+  Represents a check process of the submitted solution.
+
+  The business process is following:
+  - User submits the solution
+  - Check process is started in the background
+  - Once check process is finished successfully, the solution is marked as checked and points assigned
+  - If check process fails, the solution is marked as failed and user is notified
+
+  This particular module is ensuring, that only one check process is running for the certain solution.
+  Because solution checking is an expensive operation, we don't want to run arbitrary amount of times.
+
+  Read more about aggregates in Commanded context:
+  https://github.com/commanded/commanded/blob/master/guides/Aggregates.md
+  """
+  defstruct [:solution_uuid, status: :new, execution_errors: []]
+
+  alias Uptight.Base.Urlsafe
+
+  @type t() ::
+          %{
+            :__struct__ => __MODULE__,
+            required(:solution_uuid) => Urlsafe.t(),
+            required(:status) => :new | :started | :completed,
+            required(:execution_errors) => [String.t()] | []
+          }
+
+  alias ZhrDevs.Submissions.{Commands, Events}
+
+  def execute(%__MODULE__{status: status}, %Commands.StartCheckSolution{}) when status != :new do
+    {:error, :check_is_already_started}
+  end
+
+  def execute(
+        %__MODULE__{solution_uuid: nil, status: :new},
+        %Commands.StartCheckSolution{} = command
+      ) do
+    %Events.SolutionCheckStarted{
+      solution_uuid: command.solution_uuid,
+      task_uuid: command.task_uuid,
+      solution_path: command.solution_path
+    }
+  end
+
+  def execute(%__MODULE__{status: status}, %Commands.CompleteCheckSolution{})
+      when status != :started do
+    {:error, :illegal_attempt}
+  end
+
+  def execute(%__MODULE__{status: :started}, %Commands.CompleteCheckSolution{} = cmd) do
+    %Events.SolutionCheckCompleted{
+      solution_uuid: cmd.solution_uuid,
+      task_uuid: cmd.task_uuid,
+      points: cmd.points
+    }
+  end
+
+  ### State mutators ###
+
+  def apply(%__MODULE__{} = state, %Events.SolutionCheckStarted{} = event) do
+    %__MODULE__{
+      state
+      | solution_uuid: event.solution_uuid,
+        status: :started
+    }
+  end
+
+  def apply(%__MODULE__{} = state, %Events.SolutionCheckCompleted{}) do
+    %__MODULE__{
+      state
+      | status: :completed
+    }
+  end
+end

--- a/lib/zhr_devs/submissions/aggregates/submission.ex
+++ b/lib/zhr_devs/submissions/aggregates/submission.ex
@@ -65,7 +65,7 @@ defmodule ZhrDevs.Submissions.Aggregates.Submission do
 
   def apply(%__MODULE__{uuid: @new}, %SolutionSubmitted{} = event) do
     %__MODULE__{
-      uuid: Commanded.UUID.uuid4() |> Uptight.Base.mk_url!(),
+      uuid: event.uuid,
       attempts: 1,
       hashed_identity: event.hashed_identity,
       task_uuid: event.task_uuid,

--- a/lib/zhr_devs/submissions/commands/complete_check_solution.ex
+++ b/lib/zhr_devs/submissions/commands/complete_check_solution.ex
@@ -1,0 +1,13 @@
+defmodule ZhrDevs.Submissions.Commands.CompleteCheckSolution do
+  @moduledoc """
+  A command must contain a field to uniquely identify the aggregate instance (e.g. account_number).
+  Use @enforce_keys to force the identity field to be specified when creating the command struct.
+
+  This command will be issued by the check worker once the solution will be checked successfully.
+  """
+
+  alias ZhrDevs.Submissions.Events.SolutionCheckCompleted
+
+  @fields SolutionCheckCompleted.fields()
+  defstruct @fields
+end

--- a/lib/zhr_devs/submissions/commands/start_check_solution.ex
+++ b/lib/zhr_devs/submissions/commands/start_check_solution.ex
@@ -1,0 +1,11 @@
+defmodule ZhrDevs.Submissions.Commands.StartCheckSolution do
+  @moduledoc """
+  This command will be dispatched by the process manager once SolutionSubmitted event will occur.
+
+  There is no need to parse the command with Uptight here, because it will be dispatched by the system.
+  """
+
+  @fields [:task_uuid, :solution_uuid, :solution_path]
+  @enforce_keys @fields
+  defstruct @fields
+end

--- a/lib/zhr_devs/submissions/events/solution_check_completed.ex
+++ b/lib/zhr_devs/submissions/events/solution_check_completed.ex
@@ -1,0 +1,23 @@
+defmodule ZhrDevs.Submissions.Events.SolutionCheckCompleted do
+  @moduledoc """
+  Solution checked event is emmited once we successfully checked the solution.
+  """
+  alias Uptight.Base.Urlsafe
+
+  @fields [
+    solution_uuid: Urlsafe.new(),
+    task_uuid: Urlsafe.new(),
+    points: 0
+  ]
+  @enforce_keys Keyword.keys(@fields)
+  defstruct @fields
+
+  def fields do
+    @fields
+  end
+
+  @spec fields_keys() :: [atom()]
+  def fields_keys do
+    Keyword.keys(@fields)
+  end
+end

--- a/lib/zhr_devs/submissions/events/solution_check_started.ex
+++ b/lib/zhr_devs/submissions/events/solution_check_started.ex
@@ -1,0 +1,23 @@
+defmodule ZhrDevs.Submissions.Events.SolutionCheckStarted do
+  @moduledoc """
+  Solution checked event is emmited once we successfully checked the solution.
+  """
+  alias Uptight.Base.Urlsafe
+
+  @fields [
+    solution_uuid: Urlsafe.new(),
+    task_uuid: Urlsafe.new(),
+    solution_path: Urlsafe.new()
+  ]
+  @enforce_keys Keyword.keys(@fields)
+  defstruct @fields
+
+  def fields do
+    @fields
+  end
+
+  @spec fields_keys() :: [atom()]
+  def fields_keys do
+    Keyword.keys(@fields)
+  end
+end

--- a/lib/zhr_devs/submissions/events/solution_submitted.ex
+++ b/lib/zhr_devs/submissions/events/solution_submitted.ex
@@ -23,13 +23,11 @@ defmodule ZhrDevs.Submissions.Events.SolutionSubmitted do
           required(:solution_path) => list(Urlsafe.t())
         }
 
-  def command_fields do
+  def fields do
     @fields
   end
 
   def aggregate_fields do
-    [_ | aggregate_fields] = @fields
-
-    aggregate_fields
+    Keyword.delete(@fields, :solution_path)
   end
 end

--- a/lib/zhr_devs/submissions/events_router.ex
+++ b/lib/zhr_devs/submissions/events_router.ex
@@ -20,4 +20,7 @@ defmodule ZhrDevs.Submissions.EventsRouter do
   alias ZhrDevs.Submissions.{Aggregates, Commands}
 
   dispatch(Commands.SubmitSolution, to: Aggregates.Submission, identity: :submission_identity)
+
+  dispatch(Commands.StartCheckSolution, to: Aggregates.Check, identity: :solution_uuid)
+  dispatch(Commands.CompleteCheckSolution, to: Aggregates.Check, identity: :solution_uuid)
 end

--- a/lib/zhr_devs/submissions/process_managers/check_solution.ex
+++ b/lib/zhr_devs/submissions/process_managers/check_solution.ex
@@ -1,0 +1,53 @@
+defmodule ZhrDevs.Submissions.ProcessManagers.CheckSolution do
+  @moduledoc """
+  Process manager for checking solution.
+
+  This process will be listening for particular set of events
+  mentioned in the `interested?/1` function.
+
+  Once event is observed, the process manager will dispatch appropriate command
+
+  Process manager also maintains it's own tiny state, that will allow us
+  to not dispatch the same command twice.
+
+  Unlike the aggregate, we can omit the handle/2 and apply/2 functions
+  which we are not interesting in, in this case nothing will happens and state
+  will be preserved.
+
+  For more information about process managers, please refer to the Commanded documentation:
+  https://github.com/commanded/commanded/blob/master/guides/Process%20Managers.md
+  """
+
+  use Commanded.ProcessManagers.ProcessManager,
+    application: ZhrDevs.App,
+    name: "CheckSolutionProcessManager"
+
+  alias ZhrDevs.Submissions.Commands
+  alias ZhrDevs.Submissions.Events
+
+  defstruct status: :new
+
+  def interested?(%Events.SolutionSubmitted{uuid: solution_uuid}), do: {:start, solution_uuid}
+
+  def interested?(%Events.SolutionCheckStarted{solution_uuid: solution_uuid}),
+    do: {:continue, solution_uuid}
+
+  def interested?(%Events.SolutionCheckCompleted{solution_uuid: solution_uuid}),
+    do: {:stop, solution_uuid}
+
+  def interested?(_event), do: false
+
+  def handle(%__MODULE__{status: :new}, %Events.SolutionSubmitted{} = event) do
+    %Commands.StartCheckSolution{
+      solution_uuid: event.uuid,
+      task_uuid: event.task_uuid,
+      solution_path: event.solution_path
+    }
+  end
+
+  ### State mutators ###
+
+  def apply(%__MODULE__{status: :new} = state, %Events.SolutionCheckStarted{}) do
+    %__MODULE__{state | status: :running}
+  end
+end

--- a/lib/zhr_devs/web/presentation/helper.ex
+++ b/lib/zhr_devs/web/presentation/helper.ex
@@ -1,4 +1,6 @@
 defmodule ZhrDevs.Web.Presentation.Helper do
+  @moduledoc false
+
   use Witchcraft.Comonad
 
   alias Uptight.Result.Err

--- a/lib/zhr_devs/web/public_router.ex
+++ b/lib/zhr_devs/web/public_router.ex
@@ -6,7 +6,6 @@ defmodule ZhrDevs.Web.PublicRouter do
   use Plug.Router
   use Plug.ErrorHandler
 
-  alias ZhrDevs.Web
   alias ZhrDevs.Web.AuthCallback
 
   plug(Plug.Logger)
@@ -29,6 +28,8 @@ defmodule ZhrDevs.Web.PublicRouter do
   forward("/my", to: ZhrDevs.Web.ProtectedRouter)
 
   if Mix.env() == :dev do
+    alias ZhrDevs.Web
+
     get "/sign-in-dev" do
       mock_auth = %DomaOAuth.Authentication.Success{
         identity: "john.doe@gmail.com",

--- a/test/zhr_devs/submissions/commands/complete_check_solution_test.exs
+++ b/test/zhr_devs/submissions/commands/complete_check_solution_test.exs
@@ -1,0 +1,71 @@
+defmodule ZhrDevs.Submissions.Commands.CompleteCheckSolutionTest do
+  use ExUnit.Case, async: true
+
+  import Commanded.Assertions.EventAssertions
+
+  alias Commanded.Aggregates.Aggregate
+
+  alias ZhrDevs.App
+  alias ZhrDevs.Submissions.Aggregates.Check
+  alias ZhrDevs.Submissions.Commands.CompleteCheckSolution
+  alias ZhrDevs.Submissions.Commands.StartCheckSolution
+  alias ZhrDevs.Submissions.Events.SolutionCheckStarted
+
+  describe "StartCheckSolution command" do
+    test "do not allow to dispatch command twice with the same solution_uuid" do
+      solution_uuid = Commanded.UUID.uuid4() |> Uptight.Base.mk_url!()
+
+      :ok = simulate_check_started(solution_uuid)
+
+      command = %CompleteCheckSolution{
+        solution_uuid: solution_uuid,
+        task_uuid: "doesn't matter",
+        points: 1
+      }
+
+      assert :ok = App.dispatch(command)
+
+      assert {:error, :illegal_attempt} = App.dispatch(command)
+    end
+
+    test "Check aggregate state is predictable even after issuing the command more then once" do
+      solution_uuid = Commanded.UUID.uuid4() |> Uptight.Base.mk_url!()
+
+      :ok = simulate_check_started(solution_uuid)
+
+      command = %CompleteCheckSolution{
+        solution_uuid: solution_uuid,
+        task_uuid: "doesn't matter",
+        points: 100
+      }
+
+      for _ <- 1..3, do: App.dispatch(command)
+
+      assert %Check{
+               solution_uuid: ^solution_uuid,
+               status: :completed
+             } = Aggregate.aggregate_state(App, Check, solution_uuid.encoded)
+    end
+
+    def simulate_check_started(solution_uuid) do
+      command = %StartCheckSolution{
+        solution_uuid: solution_uuid,
+        task_uuid: "doesn't matter",
+        solution_path: "doesn't matter"
+      }
+
+      App.dispatch(command)
+
+      wait_for_event(App, SolutionCheckStarted, fn event ->
+        event.solution_uuid == solution_uuid
+      end)
+
+      assert %Check{
+               solution_uuid: ^solution_uuid,
+               status: :started
+             } = Aggregate.aggregate_state(App, Check, solution_uuid.encoded)
+
+      :ok
+    end
+  end
+end

--- a/test/zhr_devs/submissions/commands/start_check_solution_test.exs
+++ b/test/zhr_devs/submissions/commands/start_check_solution_test.exs
@@ -1,0 +1,64 @@
+defmodule ZhrDevs.Submissions.Commands.StartCheckSolutionTest do
+  use ExUnit.Case, async: true
+
+  import Commanded.Assertions.EventAssertions
+
+  alias Commanded.Aggregates.Aggregate
+
+  alias ZhrDevs.App
+  alias ZhrDevs.Submissions.Aggregates.Check
+  alias ZhrDevs.Submissions.Commands.StartCheckSolution
+  alias ZhrDevs.Submissions.Events.SolutionCheckStarted
+
+  describe "StartCheckSolution command" do
+    test "command generates a valid event" do
+      solution_uuid = Commanded.UUID.uuid4() |> Uptight.Base.mk_url!()
+      task_uuid = Commanded.UUID.uuid4() |> Uptight.Base.mk_url!()
+      solution_path = "doesn't matter"
+
+      assert :ok =
+               App.dispatch(%StartCheckSolution{
+                 solution_uuid: solution_uuid,
+                 task_uuid: task_uuid,
+                 solution_path: solution_path
+               })
+
+      assert_receive_event(
+        App,
+        SolutionCheckStarted,
+        fn event -> event.solution_uuid === solution_uuid end
+      )
+    end
+
+    test "do not allow to dispatch command twice with the same solution_uuid" do
+      solution_uuid = Commanded.UUID.uuid4()
+
+      command = %StartCheckSolution{
+        solution_uuid: solution_uuid,
+        task_uuid: "doesn't matter",
+        solution_path: "doesn't matter"
+      }
+
+      assert :ok = App.dispatch(command)
+
+      assert {:error, :check_is_already_started} = App.dispatch(command)
+    end
+
+    test "Check aggregate state is predictable even after issuing the command more then once" do
+      solution_uuid = Commanded.UUID.uuid4() |> Uptight.Base.mk_url!()
+
+      command = %StartCheckSolution{
+        solution_uuid: solution_uuid,
+        task_uuid: "doesn't matter",
+        solution_path: "doesn't matter"
+      }
+
+      for _ <- 1..3, do: App.dispatch(command)
+
+      assert %Check{
+               solution_uuid: ^solution_uuid,
+               status: :started
+             } = Aggregate.aggregate_state(App, Check, solution_uuid.encoded)
+    end
+  end
+end


### PR DESCRIPTION
Solution:
  - introduce a process manager that will be coordinating the check process
  - process manager also will ensure the only one check ever happens per submission
  - introduce a separate events for check started and check completed for more controll over the check process