### PR TITLE
Problem: to way to keep track of downloaded tasks

### DIFF
--- a/lib/zhr_devs/submissions/aggregates/submission.ex
+++ b/lib/zhr_devs/submissions/aggregates/submission.ex
@@ -28,7 +28,11 @@ defmodule ZhrDevs.Submissions.Aggregates.Submission do
   alias Uptight.Base.Urlsafe
 
   alias ZhrDevs.Submissions.Commands.SubmitSolution
+  alias ZhrDevs.Submissions.Commands.DownloadTask
+
   alias ZhrDevs.Submissions.Events.SolutionSubmitted
+  alias ZhrDevs.Submissions.Events.TaskDownloaded
+  alias ZhrDevs.Submissions.Events.TestCasesDownloaded
 
   @type t() ::
           %{
@@ -63,6 +67,22 @@ defmodule ZhrDevs.Submissions.Aggregates.Submission do
     }
   end
 
+  def execute(%__MODULE__{attempts: 0}, %DownloadTask{} = command) do
+    %TaskDownloaded{
+      hashed_identity: command.hashed_identity,
+      task_uuid: command.task_uuid,
+      technology: command.technology
+    }
+  end
+
+  def execute(%__MODULE__{attempts: 1}, %DownloadTask{} = command) do
+    %TestCasesDownloaded{
+      hashed_identity: command.hashed_identity,
+      task_uuid: command.task_uuid,
+      technology: command.technology
+    }
+  end
+
   def apply(%__MODULE__{uuid: @new}, %SolutionSubmitted{} = event) do
     %__MODULE__{
       uuid: event.uuid,
@@ -81,4 +101,7 @@ defmodule ZhrDevs.Submissions.Aggregates.Submission do
         last_attempt_at: UtcDateTime.new()
     }
   end
+
+  def apply(%__MODULE__{} = state, %TaskDownloaded{}), do: state
+  def apply(%__MODULE__{} = state, %TestCasesDownloaded{}), do: state
 end

--- a/lib/zhr_devs/submissions/commands/download_task.ex
+++ b/lib/zhr_devs/submissions/commands/download_task.ex
@@ -1,0 +1,71 @@
+defmodule ZhrDevs.Submissions.Commands.DownloadTask do
+  @moduledoc """
+  This command will be dispatched upon download task request from user
+
+  For the first submission the event will be TaskDownloaded
+  After the first submission we will attach the extended task version with tests,
+  so fields will remain the same, but event will be called TestCasesDownloaded
+  """
+
+  import ZhrDevs.Submissions.Commands.Parsing.Shared
+
+  alias ZhrDevs.Submissions.Events.TaskDownloaded
+
+  alias ZhrDevs.Submissions.SubmissionIdentity
+
+  alias ZhrDevs.App
+
+  alias Uptight.Result
+  alias Uptight.Base.Urlsafe
+
+  @fields TaskDownloaded.fields() ++ [submission_identity: nil]
+  @enforce_keys Keyword.keys(@fields)
+  defstruct @fields
+
+  @type t :: %{
+          :__struct__ => __MODULE__,
+          required(:technology) => atom(),
+          required(:hashed_identity) => Urlsafe.t(),
+          required(:task_uuid) => Urlsafe.t(),
+          required(:submission_identity) => SubmissionIdentity.t()
+        }
+
+  @typep error() :: String.t() | struct()
+
+  @spec dispatch(Keyword.t()) :: :ok | {:error, error()}
+  def dispatch(opts) do
+    case parse(opts) do
+      %Uptight.Result.Ok{} = ok_result ->
+        ok_result
+        |> Result.from_ok()
+        |> App.dispatch()
+
+      error ->
+        {:error, error}
+    end
+  end
+
+  defp parse(opts) do
+    Result.new(fn ->
+      hashed_identity =
+        opts
+        |> Keyword.fetch!(:hashed_identity)
+        |> Uptight.Base.mk_url!()
+
+      technology = unpack_technology(opts)
+
+      task_uuid =
+        opts
+        |> Keyword.fetch!(:task_uuid)
+        |> Uptight.Base.mk_url!()
+
+      %__MODULE__{
+        technology: technology,
+        hashed_identity: hashed_identity,
+        task_uuid: task_uuid,
+        submission_identity:
+          SubmissionIdentity.new(hashed_identity: hashed_identity, technology: technology)
+      }
+    end)
+  end
+end

--- a/lib/zhr_devs/submissions/commands/parsing/shared.ex
+++ b/lib/zhr_devs/submissions/commands/parsing/shared.ex
@@ -1,0 +1,24 @@
+defmodule ZhrDevs.Submissions.Commands.Parsing.Shared do
+  @moduledoc """
+  Reusable command options parsing logic
+  """
+
+  import Uptight.Assertions
+
+  @supported_technologies Enum.map(
+                            Application.compile_env(:zhr_devs, :supported_technologies),
+                            &Atom.to_string/1
+                          )
+
+  def unpack_technology(opts) do
+    passed_technology_downcase =
+      opts
+      |> Keyword.fetch!(:technology)
+      |> String.downcase()
+
+    assert passed_technology_downcase in @supported_technologies,
+           "Technology #{passed_technology_downcase} is not supported"
+
+    String.to_existing_atom(passed_technology_downcase)
+  end
+end

--- a/lib/zhr_devs/submissions/commands/submit_solution.ex
+++ b/lib/zhr_devs/submissions/commands/submit_solution.ex
@@ -13,7 +13,7 @@ defmodule ZhrDevs.Submissions.Commands.SubmitSolution do
   alias Uptight.Result
   alias Uptight.Text, as: T
 
-  import Uptight.Assertions
+  import ZhrDevs.Submissions.Commands.Parsing.Shared
 
   @fields [:uuid, :submission_identity] ++ SolutionSubmitted.fields()
   defstruct @fields
@@ -27,12 +27,6 @@ defmodule ZhrDevs.Submissions.Commands.SubmitSolution do
           required(:solution_path) => list(Urlsafe.t()),
           required(:submission_identity) => SubmissionIdentity.t()
         }
-
-  @supported_technologies Enum.map(
-                            Application.compile_env(:zhr_devs, :supported_technologies),
-                            &Atom.to_string/1
-                          )
-
   @typep error() :: String.t() | struct()
 
   @spec dispatch(Keyword.t()) :: :ok | {:error, error()}
@@ -95,18 +89,6 @@ defmodule ZhrDevs.Submissions.Commands.SubmitSolution do
     end
 
     T.new!(solution_path)
-  end
-
-  defp unpack_technology(opts) do
-    passed_technology_downcase =
-      opts
-      |> Keyword.fetch!(:technology)
-      |> String.downcase()
-
-    assert passed_technology_downcase in @supported_technologies,
-           "Technology #{passed_technology_downcase} is not supported"
-
-    String.to_existing_atom(passed_technology_downcase)
   end
 
   defp valid_zip_file?(solution_path) do

--- a/lib/zhr_devs/submissions/events/task_downloaded.ex
+++ b/lib/zhr_devs/submissions/events/task_downloaded.ex
@@ -1,0 +1,23 @@
+defmodule ZhrDevs.Submissions.Events.TaskDownloaded do
+  @moduledoc """
+  Represents an event that is emitted when user is allowed to download a task before the first submission.
+  """
+  alias Uptight.Base.Urlsafe
+
+  @fields [
+    technology: nil,
+    task_uuid: Urlsafe.new(),
+    hashed_identity: Urlsafe.new()
+  ]
+  @derive Jason.Encoder
+  defstruct @fields
+
+  @type t() :: %{
+          :__struct__ => __MODULE__,
+          required(:hashed_identity) => Urlsafe.t(),
+          required(:task_uuid) => Urlsafe.t(),
+          required(:technology) => atom()
+        }
+
+  def fields, do: @fields
+end

--- a/lib/zhr_devs/submissions/events/test_cases_downloaded.ex
+++ b/lib/zhr_devs/submissions/events/test_cases_downloaded.ex
@@ -1,0 +1,20 @@
+defmodule ZhrDevs.Submissions.Events.TestCasesDownloaded do
+  @moduledoc """
+  Represents an event that is emitted when user is allowed to download a task after the first submission.
+
+  We will send an extended version of task adding the test cases to it.
+  """
+  alias Uptight.Base.Urlsafe
+
+  alias ZhrDevs.Submissions.Events.TaskDownloaded
+
+  @derive Jason.Encoder
+  defstruct TaskDownloaded.fields()
+
+  @type t() :: %{
+          :__struct__ => __MODULE__,
+          required(:hashed_identity) => Urlsafe.t(),
+          required(:task_uuid) => Urlsafe.t(),
+          required(:technology) => atom()
+        }
+end

--- a/lib/zhr_devs/submissions/events_router.ex
+++ b/lib/zhr_devs/submissions/events_router.ex
@@ -20,6 +20,7 @@ defmodule ZhrDevs.Submissions.EventsRouter do
   alias ZhrDevs.Submissions.{Aggregates, Commands}
 
   dispatch(Commands.SubmitSolution, to: Aggregates.Submission, identity: :submission_identity)
+  dispatch(Commands.DownloadTask, to: Aggregates.Submission, identity: :submission_identity)
 
   dispatch(Commands.StartCheckSolution, to: Aggregates.Check, identity: :solution_uuid)
   dispatch(Commands.CompleteCheckSolution, to: Aggregates.Check, identity: :solution_uuid)

--- a/lib/zhr_devs/submissions/read_models/submission.ex
+++ b/lib/zhr_devs/submissions/read_models/submission.ex
@@ -26,7 +26,7 @@ defmodule ZhrDevs.Submissions.ReadModels.Submission do
   @spec increment_attempts(hashed_identity :: Uptight.Base.Urlsafe.t(), String.t()) ::
           :ok | {:error, :max_attempts_reached}
   def increment_attempts(hashed_identity, technology) do
-    technology_atom = String.to_existing_atom(technology)
+    technology_atom = safe_string_to_existing_atom(technology)
 
     GenServer.call(via_tuple(hashed_identity), {:increment_attempts, technology_atom})
   end
@@ -38,7 +38,7 @@ defmodule ZhrDevs.Submissions.ReadModels.Submission do
   ### GenServer callbacks ###
   @impl GenServer
   def init(%SolutionSubmitted{technology: technology}) do
-    technology_atom = String.to_existing_atom(technology)
+    technology_atom = safe_string_to_existing_atom(technology)
     {:ok, attempts} = do_increment_attempts(new().attempts, technology_atom)
 
     {:ok, %__MODULE__{attempts: attempts}}
@@ -93,4 +93,10 @@ defmodule ZhrDevs.Submissions.ReadModels.Submission do
   defp new_attempts do
     Enum.map(@technologies, fn technology -> {technology, @default_counter} end) |> Map.new()
   end
+
+  defp safe_string_to_existing_atom(term) when is_binary(term) do
+    String.to_existing_atom(term)
+  end
+
+  defp safe_string_to_existing_atom(term) when is_atom(term), do: term
 end

--- a/test/zhr_devs/submissions/commands/download_task_test.exs
+++ b/test/zhr_devs/submissions/commands/download_task_test.exs
@@ -1,0 +1,80 @@
+defmodule ZhrDevs.Submissions.Commands.DownloadTaskTest do
+  use ExUnit.Case, async: true
+
+  import Commanded.Assertions.EventAssertions
+
+  import ZhrDevs.Fixtures
+
+  import Hammox
+
+  alias ZhrDevs.App
+  alias ZhrDevs.Submissions.Commands.DownloadTask
+  alias ZhrDevs.Submissions.Commands.SubmitSolution
+  alias ZhrDevs.Submissions.Events.TaskDownloaded
+  alias ZhrDevs.Submissions.Events.TestCasesDownloaded
+  alias ZhrDevs.Submissions.Events.SolutionSubmitted
+
+  @task_uuid Commanded.UUID.uuid4() |> Uptight.Base.mk_url!()
+
+  describe "DownloadTask command" do
+    setup :verify_on_exit!
+
+    setup do
+      %{hid: generate_hashed_identity()}
+    end
+
+    test "with submission attempts count of 0 emit TestTaskDownloaded event", %{
+      hid: hashed_identity
+    } do
+      :ok =
+        DownloadTask.dispatch(
+          task_uuid: @task_uuid.encoded,
+          hashed_identity: hashed_identity.encoded,
+          technology: "elixir"
+        )
+
+      assert_receive_event(
+        App,
+        TaskDownloaded,
+        fn event -> event.hashed_identity === hashed_identity end
+      )
+    end
+
+    test "with already submitted solution emit TestCasesDownloaded event", %{hid: hashed_identity} do
+      expect(ZhrDevs.MockDocker, :zip_test, fn _solution_path -> true end)
+
+      :ok =
+        SubmitSolution.dispatch(
+          hashed_identity: hashed_identity.encoded,
+          task_uuid: @task_uuid.encoded,
+          technology: "elixir",
+          solution_path: "test/support/testfile.txt"
+        )
+
+      wait_for_event(App, SolutionSubmitted, fn event ->
+        event.task_uuid.encoded === @task_uuid.encoded
+      end)
+
+      :ok =
+        DownloadTask.dispatch(
+          task_uuid: @task_uuid.encoded,
+          hashed_identity: hashed_identity.encoded,
+          technology: "elixir"
+        )
+
+      assert_receive_event(
+        App,
+        TestCasesDownloaded,
+        fn event -> event.hashed_identity === hashed_identity end
+      )
+    end
+
+    @tag :skip
+    test "download of task increments global tasks read model", %{hid: hashed_identity} do
+    end
+
+    @tag :skip
+    test "download of task increments per-user read model", %{hid: hashed_identity} do
+    end
+  end
+end


### PR DESCRIPTION
Solution:
  - introduce two new events: TaskDownloaded and TestCasesDownloaded along with DownloadTask single command.