### PR TITLE
Problem: there is no explicit type declarations in via_tuple/1

### DIFF
--- a/lib/zhr_devs/identity_management.ex
+++ b/lib/zhr_devs/identity_management.ex
@@ -11,7 +11,7 @@ defmodule ZhrDevs.IdentityManagement do
     DynamicSupervisor.start_child(ZhrDevs.DynamicSupervisor, {Identity, logged_in_event})
   end
 
-  def get_identity(hashed_identity) do
+  def get_identity(%Uptight.Base.Urlsafe{} = hashed_identity) do
     case Registry.lookup(ZhrDevs.Registry, {:identity, hashed_identity}) do
       [{pid, _}] when is_pid(pid) ->
         {:ok, pid}

--- a/lib/zhr_devs/identity_management/events/logged_in.ex
+++ b/lib/zhr_devs/identity_management/events/logged_in.ex
@@ -20,3 +20,15 @@ defmodule ZhrDevs.IdentityManagement.Events.LoggedIn do
     login_at :: UtcDateTime.t()
   end
 end
+
+defimpl Commanded.Serialization.JsonDecoder, for: ZhrDevs.IdentityManagement.Events.LoggedIn do
+  alias ZhrDevs.IdentityManagement.Events.LoggedIn
+
+  def decode(%LoggedIn{} = event) do
+    %LoggedIn{
+      identity: Uptight.Text.new(event.identity),
+      hashed_identity: Uptight.Base.mk_url!(event.hashed_identity),
+      login_at: UtcDateTime.new(event.login_at)
+    }
+  end
+end

--- a/lib/zhr_devs/identity_management/read_models/identity.ex
+++ b/lib/zhr_devs/identity_management/read_models/identity.ex
@@ -41,7 +41,7 @@ defmodule ZhrDevs.IdentityManagement.ReadModels.Identity do
     {:reply, :ok, %__MODULE__{state | login_at: new_login_at}}
   end
 
-  defp via_tuple(hashed_identity) do
-    {:via, Registry, {ZhrDevs.Registry, {:identity, to_string(hashed_identity)}}}
+  defp via_tuple(%Uptight.Base.Urlsafe{} = hashed_identity) do
+    {:via, Registry, {ZhrDevs.Registry, {:identity, hashed_identity}}}
   end
 end

--- a/lib/zhr_devs/submissions/events/solution_submitted.ex
+++ b/lib/zhr_devs/submissions/events/solution_submitted.ex
@@ -32,3 +32,17 @@ defmodule ZhrDevs.Submissions.Events.SolutionSubmitted do
     Keyword.delete(@fields, :solution_path)
   end
 end
+
+defimpl Commanded.Serialization.JsonDecoder, for: ZhrDevs.Submissions.Events.SolutionSubmitted do
+  alias ZhrDevs.Submissions.Events.SolutionSubmitted
+
+  def decode(%SolutionSubmitted{} = event) do
+    %SolutionSubmitted{
+      uuid: Uptight.Text.new!(event.uuid),
+      task_uuid: Uptight.Text.new!(event.task_uuid),
+      hashed_identity: Uptight.Base.mk_url!(event.hashed_identity),
+      technology: String.to_existing_atom(event.technology),
+      solution_path: Uptight.Text.new!(event.solution_path)
+    }
+  end
+end

--- a/lib/zhr_devs/submissions/read_models/submission.ex
+++ b/lib/zhr_devs/submissions/read_models/submission.ex
@@ -91,8 +91,8 @@ defmodule ZhrDevs.Submissions.ReadModels.Submission do
   end
 
   ### Private functions ###
-  defp via_tuple(hashed_identity) do
-    {:via, Registry, {ZhrDevs.Registry, {:submissions, to_string(hashed_identity)}}}
+  defp via_tuple(%Uptight.Base.Urlsafe{} = hashed_identity) do
+    {:via, Registry, {ZhrDevs.Registry, {:submissions, hashed_identity}}}
   end
 
   defp do_increment_attempts(attempts, task) do

--- a/lib/zhr_devs/utc_datetime.ex
+++ b/lib/zhr_devs/utc_datetime.ex
@@ -11,6 +11,10 @@ defmodule UtcDateTime do
     %__MODULE__{dt: DateTime.utc_now()}
   end
 
+  def new(%DateTime{} = dt) do
+    %__MODULE__{dt: dt}
+  end
+
   defimpl Jason.Encoder, for: UtcDateTime do
     def encode(value, _opts) do
       [?", DateTime.to_iso8601(value.dt), ?"]

--- a/lib/zhr_devs/web/protected_router.ex
+++ b/lib/zhr_devs/web/protected_router.ex
@@ -62,7 +62,9 @@ defmodule ZhrDevs.Web.ProtectedRouter do
 
   defp lookup_identity(nil), do: :unauthenticated
 
-  defp lookup_identity(hashed_identity) do
+  defp lookup_identity(binary_hashed_identity) do
+    hashed_identity = Uptight.Base.mk_url!(binary_hashed_identity)
+
     case IdentityManagement.get_identity(hashed_identity) do
       {:ok, _pid} ->
         :ok

--- a/test/zhr_devs/identity_management/commands_test.exs
+++ b/test/zhr_devs/identity_management/commands_test.exs
@@ -1,6 +1,8 @@
 defmodule ZhrDevs.IdentityManagement.CommandsTest do
   use ExUnit.Case, async: true
 
+  @moduletag :capture_log
+
   import Commanded.Assertions.EventAssertions
 
   import ZhrDevs.Web.Presentation.Helper, only: [extract_error: 1]

--- a/test/zhr_devs/submissions/commands/complete_check_solution_test.exs
+++ b/test/zhr_devs/submissions/commands/complete_check_solution_test.exs
@@ -1,6 +1,8 @@
 defmodule ZhrDevs.Submissions.Commands.CompleteCheckSolutionTest do
   use ExUnit.Case, async: true
 
+  @moduletag :capture_log
+
   import Commanded.Assertions.EventAssertions
 
   alias Commanded.Aggregates.Aggregate

--- a/test/zhr_devs/submissions/commands/start_check_solution_test.exs
+++ b/test/zhr_devs/submissions/commands/start_check_solution_test.exs
@@ -1,6 +1,8 @@
 defmodule ZhrDevs.Submissions.Commands.StartCheckSolutionTest do
   use ExUnit.Case, async: true
 
+  @moduletag :capture_log
+
   import Commanded.Assertions.EventAssertions
 
   alias Commanded.Aggregates.Aggregate

--- a/test/zhr_devs/submissions/read_models/submission_test.exs
+++ b/test/zhr_devs/submissions/read_models/submission_test.exs
@@ -1,6 +1,8 @@
 defmodule ZhrDevs.Submissions.ReadModels.SubmissionTest do
   use ExUnit.Case, async: false
 
+  @moduletag :capture_log
+
   alias ZhrDevs.Submissions
   alias ZhrDevs.Submissions.Events.SolutionSubmitted
   alias ZhrDevs.Submissions.ReadModels.Submission
@@ -24,11 +26,11 @@ defmodule ZhrDevs.Submissions.ReadModels.SubmissionTest do
       successful_auth = generate_successful_auth(:github)
 
       trigger_event = %SolutionSubmitted{
-        hashed_identity: successful_auth.hashed_identity,
+        hashed_identity: Uptight.Base.mk_url!(successful_auth.hashed_identity),
         technology: "goo",
-        uuid: Commanded.UUID.uuid4(),
-        task_uuid: @task.uuid,
-        solution_path: "test/support/testfile.txt"
+        uuid: Commanded.UUID.uuid4() |> Uptight.Text.new!(),
+        task_uuid: Commanded.UUID.uuid4() |> Uptight.Text.new!(),
+        solution_path: Uptight.Text.new!("test/support/testfile.txt")
       }
 
       %{event: trigger_event}
@@ -61,12 +63,14 @@ defmodule ZhrDevs.Submissions.ReadModels.SubmissionTest do
 
   describe "start_link/1" do
     setup do
+      successful_auth = generate_successful_auth(:github)
+
       trigger_event = %SolutionSubmitted{
-        hashed_identity: generate_hashed_identity(),
+        hashed_identity: Uptight.Base.mk_url!(successful_auth.hashed_identity),
         technology: "goo",
-        uuid: Commanded.UUID.uuid4(),
-        task_uuid: @task.uuid,
-        solution_path: "test/support/testfile.txt"
+        uuid: Commanded.UUID.uuid4() |> Uptight.Text.new!(),
+        task_uuid: Commanded.UUID.uuid4() |> Uptight.Text.new!(),
+        solution_path: Uptight.Text.new!("test/support/testfile.txt")
       }
 
       %{event: trigger_event}

--- a/test/zhr_devs/submissions/submission_identity_test.exs
+++ b/test/zhr_devs/submissions/submission_identity_test.exs
@@ -1,6 +1,8 @@
 defmodule ZhrDevs.Submissions.SubmissionIdentityTest do
   use ExUnit.Case, async: true
 
+  @moduletag :capture_log
+
   alias Uptight.Text
 
   alias ZhrDevs.Submissions.SubmissionIdentity

--- a/test/zhr_devs/web/protected_router_test.exs
+++ b/test/zhr_devs/web/protected_router_test.exs
@@ -28,7 +28,7 @@ defmodule ZhrDevs.Web.ProtectedRouterTest do
     test "with authenticated identity and no spawned process - threat as :unauthenticated, halt connection" do
       conn =
         conn(:get, "/")
-        |> init_test_session(%{hashed_identity: "nonesense"})
+        |> init_test_session(%{hashed_identity: DomaOAuth.hash("nonesense@gmail.com")})
         |> ProtectedRouter.call(@routes)
 
       assert conn.halted


### PR DESCRIPTION
Solution: serialize the event so that we get what we declare in types from the database. With that in place, we can use %Uptight.Base.Urlsafe{} as a registry key.