### PR TITLE
Problem: no way to debug CommandRunner output systematically

### DIFF
--- a/lib/zhr_devs/bakery_integration/commands/command.ex
+++ b/lib/zhr_devs/bakery_integration/commands/command.ex
@@ -9,11 +9,14 @@ defmodule ZhrDevs.BakeryIntegration.Commands.Command do
           message: term()
         }
 
-  @type cmd() :: Ubuntu.Command.t()
+  @type options() :: [
+          {:cmd, Ubuntu.Command.t()},
+          {:logger_metadata, Keyword.t()}
+        ]
 
   @type run() :: {:ok, pid()} | {:error, term()}
 
-  @callback run(cmd()) :: run()
+  @callback run(options()) :: run()
   @callback build(opts :: Keyword.t()) :: Uptight.Result.t()
   @callback on_success(Keyword.t()) :: :ok | {:error, system_error()}
   @callback on_failure(system_error(), Keyword.t()) :: :ok

--- a/lib/zhr_devs/bakery_integration/commands/gen_multiplayer.ex
+++ b/lib/zhr_devs/bakery_integration/commands/gen_multiplayer.ex
@@ -38,8 +38,8 @@ defmodule ZhrDevs.BakeryIntegration.Commands.GenMultiplayer do
   def gen_multiplayer, do: @gen_multiplayer
 
   @impl Command
-  def run(%Ubuntu.Command{} = cmd) do
-    ZhrDevs.Submissions.start_automatic_check(cmd)
+  def run(opts) do
+    ZhrDevs.Submissions.start_automatic_check(opts)
   end
 
   @impl Command

--- a/lib/zhr_devs/bakery_integration/queue.ex
+++ b/lib/zhr_devs/bakery_integration/queue.ex
@@ -145,8 +145,9 @@ defmodule ZhrDevs.BakeryIntegration.Queue do
 
     command_module = Keyword.fetch!(options, :command_module)
     command = Keyword.fetch!(options, :cmd)
+    logger_metadata = Keyword.get(options, :logger_metadata, [])
 
-    {:ok, pid} = command_module.run(command)
+    {:ok, pid} = command_module.run(cmd: command, logger_metadata: logger_metadata)
 
     running_check = %RunningCheck{
       retries: 0,
@@ -192,8 +193,9 @@ defmodule ZhrDevs.BakeryIntegration.Queue do
       ) do
     command_module = Keyword.fetch!(running_check.restart_opts, :command_module)
     command = Keyword.fetch!(running_check.restart_opts, :cmd)
+    logger_metadata = Keyword.get(running_check.restart_opts, :logger_metadata, [])
 
-    {:ok, pid} = command_module.run(command)
+    {:ok, pid} = command_module.run(cmd: command, logger_metadata: logger_metadata)
 
     updated_running_check = %RunningCheck{
       running_check

--- a/lib/zhr_devs/submissions/automatic_check_runner.ex
+++ b/lib/zhr_devs/submissions/automatic_check_runner.ex
@@ -85,7 +85,11 @@ defmodule ZhrDevs.Submissions.AutomaticCheckRunner do
       check_uuid: event.solution_uuid,
       task_uuid: event.task_uuid,
       type: :automatic,
-      command_module: command_module
+      command_module: command_module,
+      logger_metadata: [
+        backend: event.solution_uuid |> T.un() |> String.to_atom(),
+        path: "/tmp/#{task.name}/#{task.technology}/#{T.un(event.solution_uuid)}.log"
+      ]
     ]
 
     command_specific_options = opts |> command_module.build() |> Uptight.Result.from_ok()
@@ -108,7 +112,11 @@ defmodule ZhrDevs.Submissions.AutomaticCheckRunner do
       check_uuid: event.uuid,
       type: :manual,
       triggered_by: event.triggered_by,
-      command_module: ZhrDevs.BakeryIntegration.command_module(task)
+      command_module: ZhrDevs.BakeryIntegration.command_module(task),
+      logger_metadata: [
+        backend: event.uuid |> T.un() |> String.to_atom(),
+        path: "/tmp/#{task.name}/#{task.technology}/manual/#{T.un(event.uuid)}.log"
+      ]
     ]
 
     command_specific_options = opts |> command_module.build() |> Uptight.Result.from_ok()


### PR DESCRIPTION
Solution:
  - attach a logger backend to each CommandRunner process